### PR TITLE
Use pnpm un + add to fix ref issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ To test changes locally, update the version in this repository using
 `npm version --no-git-tag-version preminor` (use `premajor` instead if the change is breaking), and
 install this repository as a file-based dependency:
 
-- Website: `cd apps/website && pnpm add file:../../../data && pnpm update @alveusgg/data`
+- Website: `cd apps/website && pnpm remove @alveusgg/data && pnpm add file:../../../data`
 - Extension: `npm install file:../data`
 
 Alternatively, push the pre-release branch to GitHub and install it as a GitHub-based dependency:
 
-- Website: `cd apps/website && pnpm add github:alveusgg/data#<branch name> && pnpm update @alveusgg/data`
+- Website: `cd apps/website && pnpm remove @alveusgg/data && pnpm add github:alveusgg/data#<branch name>`
 - Extension: `npm install github:alveusgg/data#<branch name>`
 
 When the change is ready to release, update the version in this repository using
@@ -26,5 +26,5 @@ pull request.
 
 Once the pull request is merged, update the GitHub-based dependency in the website and extension:
 
-- Website: `cd apps/website && pnpm add github:alveusgg/data && pnpm update @alveusgg/data`
+- Website: `cd apps/website && pnpm remove @alveusgg/data && pnpm add github:alveusgg/data`
 - Extension: `npm install github:alveusgg/data`


### PR DESCRIPTION
After landing #5, I ran into:

```
pnpm add github:alveusgg/data

 ERROR  Could not resolve MattIPv4/winnie-animal-quest to a commit of https://github.com/alveusgg/data.git.

This error happened while installing a direct dependency of /Users/mattcowley/WebstormProjects/alveusgg/alveusgg/apps/website

pnpm: Could not resolve MattIPv4/winnie-animal-quest to a commit of https://github.com/alveusgg/data.git.
    at resolveRefFromRefs (/usr/local/Cellar/pnpm/7.27.0/libexec/dist/pnpm.cjs:108955:17)
    at resolveRef (/usr/local/Cellar/pnpm/7.27.0/libexec/dist/pnpm.cjs:108948:14)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async resolveGit (/usr/local/Cellar/pnpm/7.27.0/libexec/dist/pnpm.cjs:108898:24)
    at async Object.resolve (/usr/local/Cellar/pnpm/7.27.0/libexec/dist/pnpm.cjs:110227:173)
    at async run (/usr/local/Cellar/pnpm/7.27.0/libexec/dist/pnpm.cjs:122957:23)
../..                                    | Progress: resolved 80, reused 80, downloaded 0, added 0
```

`pnpm remove @alveusgg/data && pnpm add github:alveusgg/data` resolves this, ensuring consistent, correct installs