### PR TITLE
Set toaster strudel sex to null

### DIFF
--- a/src/ambassadors/core.ts
+++ b/src/ambassadors/core.ts
@@ -683,7 +683,7 @@ const ambassadors = {
     alternate: [],
     species: "Blue-tounged Skink",
     scientific: "Tiliqua scincoides intermedia",
-    sex: "Male",
+    sex: null,
     birth: "2022-07-04",
     arrival: "2022-11",
     retired: null,


### PR DESCRIPTION
I think we do not know toasters strudels sex, so it probably should be null. But maya refers to them as him. So not sure whats best. https://www.twitch.tv/videos/1815527092?t=02h17m34s