### PR TITLE
Fix ambassador key filters to check key exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alveusgg/data",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/ambassadors/filters.ts
+++ b/src/ambassadors/filters.ts
@@ -31,6 +31,7 @@ export const isAmbassadorWithPlushKey = <
 >(
   key: string
 ): key is AmbassadorWithPlushKey<Items> =>
+  key in ambassadors &&
   ambassadors[key as keyof typeof ambassadors].plush !== null;
 
 export const isAmbassadorWithPlush = <
@@ -76,6 +77,7 @@ export const isActiveAmbassadorKey = <
 >(
   key: string
 ): key is ActiveAmbassadorKey<Items> =>
+  key in ambassadors &&
   ambassadors[key as keyof typeof ambassadors].retired === null;
 
 export const isActiveAmbassador = <


### PR DESCRIPTION
`isActiveAmbassadorKey` (and `isAmbassadorWithPlushKey`) were typed as taking any `string`, but then made an assumption that the string given was a key on `ambassadors`. This PR updates the logic to first check the key exists before using the key to access a property.