### PR TITLE
Rename "Cow Edition" animal quest to "Beef Edition"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.23.0",
+  "version": "0.24.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alveusgg/data",
-      "version": "0.23.0",
+      "version": "0.24.0-0",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.24.0-0",
+  "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alveusgg/data",
-      "version": "0.24.0-0",
+      "version": "0.24.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.24.0-0",
+  "version": "0.24.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.23.0",
+  "version": "0.24.0-0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/animal-quest.ts
+++ b/src/animal-quest.ts
@@ -276,7 +276,7 @@ const animalQuest: Readonly<AnimalQuest[]> = [
       id: 1808632737,
       start: "00h03m15s",
     },
-    edition: "Cow Edition",
+    edition: "Beef Edition",
     description:
       "Learn about Winnie, Alveus' Red Angus Beef Cow, the beef industry and commercial agriculture. Discover the impacts it has on our planet, the concerns for animal welfare in the industry, and recommendations for how we can all make a difference.",
     broadcast: new Date("2023-04-29"),
@@ -402,7 +402,7 @@ export type AnimalQuestWithRelation = AnimalQuestWithEpisode & {
 
 export const getAmbassadorEpisode = (
   ambassador: AmbassadorKey | string,
-  type?: "featured" | "related",
+  type?: "featured" | "related"
 ): AnimalQuestWithRelation | undefined => {
   if (!isAmbassadorKey(ambassador)) return undefined;
 

--- a/src/animal-quest.ts
+++ b/src/animal-quest.ts
@@ -402,7 +402,7 @@ export type AnimalQuestWithRelation = AnimalQuestWithEpisode & {
 
 export const getAmbassadorEpisode = (
   ambassador: AmbassadorKey | string,
-  type?: "featured" | "related"
+  type?: "featured" | "related",
 ): AnimalQuestWithRelation | undefined => {
   if (!isAmbassadorKey(ambassador)) return undefined;
 


### PR DESCRIPTION
Rename (first) cow animal quest to "Beef Edition".

Website PR: https://github.com/alveusgg/alveusgg/pull/460
Extension PR: n/a (aq does not show on the extension)