### PR TITLE
Polly's arrival date should reflect her return from retirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alveusgg/data",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/ambassadors/core.ts
+++ b/src/ambassadors/core.ts
@@ -888,7 +888,7 @@ const ambassadors = {
     scientific: "Gallus gallus domesticus",
     sex: "Female",
     birth: null,
-    arrival: "2022-08",
+    arrival: "2023-11", // Previously 2022-08 to 2022-11
     retired: null,
     iucn: {
       id: null,


### PR DESCRIPTION
Per Maya, either date is fine, but a preference was indicated for listing Polly by the more recent date. This will also mean we have an ambassador listed under the 2023 heading on the ambassador page.