### PR TITLE
Fix spelling of "tongued" for Toaster Strudel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alveusgg/data",
-      "version": "0.37.0",
+      "version": "0.37.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/ambassadors/images.ts
+++ b/src/ambassadors/images.ts
@@ -485,24 +485,24 @@ const ambassadorImages: {
   toasterStrudel: [
     {
       src: toasterStrudelImage1,
-      alt: "Toaster Strudel the Blue-tounged Skink",
+      alt: "Toaster Strudel the Blue-tongued Skink",
       position: "25% 50%",
     },
     {
       src: toasterStrudelImage2,
-      alt: "Toaster Strudel the Blue-tounged Skink",
+      alt: "Toaster Strudel the Blue-tongued Skink",
     },
     {
       src: toasterStrudelImage3,
-      alt: "Toaster Strudel the Blue-tounged Skink",
+      alt: "Toaster Strudel the Blue-tongued Skink",
     },
     {
       src: toasterStrudelImage4,
-      alt: "Toaster Strudel the Blue-tounged Skink",
+      alt: "Toaster Strudel the Blue-tongued Skink",
     },
     {
       src: toasterStrudelImage5,
-      alt: "Toaster Strudel the Blue-tounged Skink",
+      alt: "Toaster Strudel the Blue-tongued Skink",
     },
   ],
   tortellini: [

--- a/src/animal-quest.ts
+++ b/src/animal-quest.ts
@@ -242,9 +242,9 @@ const animalQuest: Readonly<AnimalQuest[]> = [
       id: 1732218911,
       start: "00h15m24s",
     },
-    edition: "Blue-tounged Skink Edition",
+    edition: "Blue-tongued Skink Edition",
     description:
-      "Get to know Toast, Alveus' Blue-tounged Skink, and learn about the history of the species, deimatic display in skinks, and ovoviviparous birth. We'll also investigate the dangers they face in the wild, such as bioaccumlation and biomagnification, as well as the pet trade globally.",
+      "Get to know Toast, Alveus' Blue-tongued Skink, and learn about the history of the species, deimatic display in skinks, and ovoviviparous birth. We'll also investigate the dangers they face in the wild, such as bioaccumlation and biomagnification, as well as the pet trade globally.",
     broadcast: new Date("2023-01-31"),
     host: "maya",
     length: 60 * 60 + 17 * 60 + 13, // 00:15:24 - 01:32:27


### PR DESCRIPTION
I noticed there were a few typos on [Toaster Strudel's page](https://www.alveussanctuary.org/ambassadors/toaster-strudel) where `tongued` is misspelled. This PR fixes those typos.