### PR TITLE
Add Zod schema for ambassadors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@alveusgg/data",
       "version": "0.47.0",
       "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.0",
         "@typescript-eslint/parser": "^6.2.0",
@@ -3165,6 +3168,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -5308,6 +5319,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alveusgg/data",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@alveusgg/data",
       "version": "0.47.0",
       "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "zod": "^3.23.8"
-      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.2.0",
         "@typescript-eslint/parser": "^6.2.0",
@@ -19,7 +16,17 @@
         "lint-staged": "^15.2.10",
         "prettier": "^3.0.0",
         "tailwindcss": "^3.4.14",
-        "typescript": "^5.1.6"
+        "typescript": "^5.1.6",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "tailwindcss": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3170,9 +3177,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5321,9 +5329,10 @@
       "dev": true
     },
     "zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,16 @@
     "lint-staged": "^15.2.10",
     "prettier": "^3.0.0",
     "tailwindcss": "^3.4.14",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "zod": "^3.24.1"
   },
-  "dependencies": {
-    "zod": "^3.23.8"
+  "peerDependencies": {
+    "tailwindcss": "^3.0.0",
+    "zod": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "prettier": "^3.0.0",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.1.6"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alveusgg/data",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {

--- a/src/ambassadors/images.ts
+++ b/src/ambassadors/images.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { isAmbassadorKey, type Ambassadors, type AmbassadorKey } from "./core";
 import {
   isAmbassadorWithPlushKey,
@@ -220,13 +222,30 @@ import winnieTheMooImageIcon from "../../assets/ambassadors/winnieTheMoo/icon.pn
 
 type OneToNine = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 type ZeroToNine = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
-type Percentage = `${OneToNine}${ZeroToNine}%` | `${ZeroToNine}%` | "100%";
+type Percentage = `${ZeroToNine}%` | `${OneToNine}${ZeroToNine}%` | "100%";
+type Position = `${Percentage} ${Percentage}`;
 
-export type AmbassadorImage = {
-  src: typeof stompyImage1;
-  alt: string;
-  position?: `${Percentage} ${Percentage}`;
+const isPercentage = (str: string): str is Percentage =>
+  /^(100|[1-9]?[0-9])%$/.test(str);
+const isPosition = (str: string): str is Position => {
+  const [x, y, ...rest] = str.split(" ");
+  return rest.length === 0 && !!x && !!y && isPercentage(x) && isPercentage(y);
 };
+
+export const ambassadorImageSchema = z.object({
+  // Use an always true refine to narrow down the type
+  // Ensure the image import type includes jpg + png
+  src: z
+    .unknown()
+    .refine(
+      (src: unknown): src is typeof abbottImage1 | typeof abbottImageIcon =>
+        true,
+    ),
+  alt: z.string(),
+  position: z.string().refine(isPosition).optional(),
+});
+
+export type AmbassadorImage = z.infer<typeof ambassadorImageSchema>;
 export type AmbassadorImages = [AmbassadorImage, ...AmbassadorImage[]];
 
 const ambassadorImages: {

--- a/src/ambassadors/lifespans.ts
+++ b/src/ambassadors/lifespans.ts
@@ -1,9 +1,16 @@
-export type Lifespan = {
-  // In years
-  wild?: number | { min: number; max: number };
-  captivity?: number | { min: number; max: number };
-  source: string;
-};
+import { z } from "zod";
+
+export const lifespanSchema = z.object({
+  wild: z
+    .union([z.number(), z.object({ min: z.number(), max: z.number() })])
+    .optional(),
+  captivity: z
+    .union([z.number(), z.object({ min: z.number(), max: z.number() })])
+    .optional(),
+  source: z.string(),
+});
+
+export type Lifespan = z.infer<typeof lifespanSchema>;
 
 const lifespans = {
   emu: {

--- a/src/iucn.ts
+++ b/src/iucn.ts
@@ -19,19 +19,29 @@ type IUCNStatuses = keyof typeof iucnStatuses;
 type ICUNFlags = keyof typeof iucnFlags;
 export type IUCNStatus = IUCNStatuses | `${IUCNStatuses}/${ICUNFlags}`;
 
-const isIUCNStatus = (str: string): str is IUCNStatuses =>
-  Object.keys(iucnStatuses).includes(str as IUCNStatuses);
+const isIUCNStatuses = (str: string): str is IUCNStatuses =>
+  Object.keys(iucnStatuses).includes(str);
 
-const isIUCNFlag = (str: string): str is ICUNFlags =>
-  Object.keys(iucnFlags).includes(str as ICUNFlags);
+const isIUCNFlags = (str: string): str is ICUNFlags =>
+  Object.keys(iucnFlags).includes(str);
+
+export const isIUCNStatus = (str: string): str is IUCNStatus => {
+  const [status, flag, ...rest] = str.split("/");
+  if (!status || rest.length > 0) return false;
+
+  if (!isIUCNStatuses(status)) return false;
+  if (flag !== undefined && !isIUCNFlags(flag)) return false;
+
+  return true;
+};
 
 export const getIUCNStatus = (fullStatus: IUCNStatus): string => {
   const [status, flag] = fullStatus.split("/");
 
-  if (!status || !isIUCNStatus(status))
+  if (!status || !isIUCNStatuses(status))
     throw new Error(`Invalid IUCN status: ${status}`);
   if (!flag) return iucnStatuses[status];
 
-  if (!isIUCNFlag(flag)) throw new Error(`Invalid IUCN flag: ${flag}`);
+  if (!isIUCNFlags(flag)) throw new Error(`Invalid IUCN flag: ${flag}`);
   return `${iucnStatuses[status]} ${iucnFlags[flag]}`;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,15 @@ export type PartialDateString =
   | DateStringYearMonth
   | DateString;
 
+export const isPartialDateString = (
+  value: string,
+): value is PartialDateString => {
+  const year = "(19|20)\\d{2}";
+  const month = "(0[1-9]|1[0-2])";
+  const day = "(0[1-9]|[12][0-9]|3[01])";
+  return new RegExp(
+    `^(${year}|${year}-${month}|${year}-${month}-${day})$`,
+  ).test(value);
+};
+
 export type Nullable<T> = T | null;


### PR DESCRIPTION
In support of the work on the extension to allow it to fetch ambassador data in real-time from the website, adding schemas for the core data so that it may validate the structure of the API data.