### PR TITLE
Set --no-git-checks in IUCN version update

### DIFF
--- a/.github/workflows/update-iucn.yml
+++ b/.github/workflows/update-iucn.yml
@@ -45,7 +45,7 @@ jobs:
           fi
 
           # Bump the version
-          pnpm version minor --no-git-tag-version
+          pnpm version minor --no-git-checks --no-git-tag-version
 
           # Output the new version
           echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Missed this in #282, fixes https://github.com/alveusgg/data/actions/runs/29296422597/job/86970832750