### PR TITLE
Bump pnpm from 11.20.0 to 11.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "url": "https://github.com/alveusgg/data/issues"
   },
   "engines": {
-    "pnpm": "^11.20.0"
+    "pnpm": "^11.22.0"
   },
-  "packageManager": "pnpm@11.20.0",
+  "packageManager": "pnpm@11.22.0",
   "scripts": {
     "lint": "eslint \"**/*.ts\"",
     "lint:fix": "eslint \"**/*.ts\" --fix",


### PR DESCRIPTION
Generated via `pnpm self-update`.

Check this workflow's logs at https://github.com/alveusgg/data/actions/runs/31980926086.